### PR TITLE
NOISSUE updates echo-service to dropwizard 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/mas
 apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/master/upside-autovalue.gradle'
 apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/master/upside-jacoco.gradle'
 apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/master/upside-jacoco-multimodule.gradle'
-apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/master/upside-dependency-management.gradle'
+apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/dw_135_upgrade/upside-dependency-management.gradle'
 
 defaultTasks 'cleanIdea', 'idea', 'snapshot', 'test', 'build', 'publishToMavenLocal', 'jacocoTestReport', 'jacocoRootReport'
 

--- a/echo-service-db/src/test/java/com/upside/echo/test/util/TransientServiceDBRule.java
+++ b/echo-service-db/src/test/java/com/upside/echo/test/util/TransientServiceDBRule.java
@@ -9,28 +9,21 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
+import java.util.List;
 import org.flywaydb.core.Flyway;
 import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
-
-import java.util.List;
 
 /**
  * Test rule to setup and teardown a database for testing.
  */
 public class TransientServiceDBRule extends ExternalResource {
 
-    private DBI dbi;
     private final List<String> tables;
-
-    public DBI getDbi() {
-        return this.dbi;
-    }
-
-    private ManagedDataSource dataSource;
-
     private final MySQLRule mySQLRule;
+    private ManagedDataSource dataSource;
+    private DBI dbi;
 
     public TransientServiceDBRule(MySQLRule rule, String ... tables) {
         this.mySQLRule = rule;
@@ -39,6 +32,10 @@ public class TransientServiceDBRule extends ExternalResource {
 
     public MySQLRule getMySQLRule() {
         return this.mySQLRule;
+    }
+
+    public DBI getDbi() {
+        return this.dbi;
     }
 
     @Override
@@ -53,6 +50,7 @@ public class TransientServiceDBRule extends ExternalResource {
         dataSourceFactory.setUrl(this.mySQLRule.getDbUrl());
         dataSourceFactory.setUser(this.mySQLRule.getDbUser());
         dataSourceFactory.setPassword(this.mySQLRule.getDbPassword());
+        dataSourceFactory.setDriverClass(MySQLRule.DRIVER_CLASSNAME);
         this.dataSource = dataSourceFactory.build(new MetricRegistry(), "test");
         this.dbi = new DBIFactory().build(environment, dataSourceFactory, this.dataSource, "test");
         this.dbi.registerArgumentFactory(new UUIDArgumentFactory());


### PR DESCRIPTION
Tested by getting IntTests to pass and then ran docker-compose build &&
docker-compose up:

![screen shot 2018-10-03 at 9 52 29 pm](https://user-images.githubusercontent.com/620123/46448822-cfaaeb00-c756-11e8-9903-c43242cfb51f.png)

Note - this is generally related to [this PRs](https://github.com/upside-services/mysql-rule/pull/2)  and [this branch](https://github.com/upside-services/upside-gradle/blob/dw_135_upgrade/upside-dependency-management.gradle) that I will turn in to a PR once I get all the compatible dependencies sorted out

I'm using echo-service as a 'canary in the coalmine' to see how bad a potential break will be;  after I figured out that the driverName is now _required_ in the datasource, it turned out not to be too bad.
